### PR TITLE
 Workflow to add new issue/PR to project

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -1,0 +1,24 @@
+name: Add new issue/PR to project
+
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+
+  pull_request_target:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue or PR to project
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+
+      - name: add-to-project
+        uses: ./
+        with:
+          avocado-project: true

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ needed by various of avocado projects.
 
 ## Supported tools:
 - avocado-static-checks
+- avocado-project manipulation
 
 ## Input
 
@@ -12,7 +13,11 @@ avocado-static-checks:
     Runs avocado-static-checks on pull requests.
     Default is false.
   default: false
-
+  avocado-project:
+    description: |
+      Mr. avocado configuration for manipulating with PR and issues.
+      Default is false.
+    default: false
 ```
 ## Usage
 


### PR DESCRIPTION
This workflow will add every new issue/PR to avocado project, so we will
have all issues/PR on one project board. Also, it updates some leftovers in README file.

Reference: https://github.com/orgs/avocado-framework/projects/1
Signed-off-by: Jan Richter <jarichte@redhat.com>