### PR TITLE
Bot IDs as inputs for generating access tokens

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -22,3 +22,6 @@ jobs:
         uses: ./
         with:
           avocado-project: true
+          bot_app_id: ${{ secrets.MR_AVOCADO_ID }}
+          bot_app_installation_id: ${{ secrets.MR_AVOCADO_INSTALLATION_ID }}
+          bot_app_private_key: ${{ secrets.MR_AVOCADO_PRIVATE_KEY }}

--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ avocado-static-checks:
       Mr. avocado configuration for manipulating with PR and issues.
       Default is false.
     default: false
+  bot_app_id:
+    description: |
+      Bot app ID which is needed to generate access token for bot. It is required by avocado-project.
+    default: ''
+  bot_app_installation_id:
+    description: |
+      Bot app installation ID which is needed to generate access token for bot. It is required by avocado-project.
+    default: ''
+  bot_app_private_key:
+    description: |
+      Bot app private key which is needed to generate access token for bot. It is required by avocado-project.
+    default: ''
 ```
 ## Usage
 

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,18 @@ inputs:
       Mr. avocado configuration for manipulating with PR and issues.
       Default is false.
     default: false
+  bot_app_id:
+    description: |
+      Bot app ID which is needed to generate access token for bot. It is required by avocado-project.
+    default: ''
+  bot_app_installation_id:
+    description: |
+      Bot app installation ID which is needed to generate access token for bot. It is required by avocado-project.
+    default: ''
+  bot_app_private_key:
+    description: |
+      Bot app private key which is needed to generate access token for bot. It is required by avocado-project.
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -31,9 +43,9 @@ runs:
       id: generate_token
       uses: tibdex/github-app-token@021a2405c7f990db57f5eae5397423dcc554159c
       with:
-        app_id: ${{ secrets.MR_AVOCADO_ID }}
-        installation_id: ${{ secrets.MR_AVOCADO_INSTALLATION_ID }}
-        private_key: ${{ secrets.MR_AVOCADO_PRIVATE_KEY }}
+        app_id: ${{ inputs.bot_app_id }}
+        installation_id: ${{ inputs.bot_app_installation_id }}
+        private_key: ${{ inputs.bot_app_private_key }}
     - if: ${{ inputs.avocado-project == 'true' }}
       name: Get project data
       env:


### PR DESCRIPTION
This is a fix for avocado-project tools which use MR. Avocado bot for manipulation with issue and PR. This tool needs MR. Avocados IDs, which is stored in Avocado organization as secrets. Unfortunately, the composite actions cannot use organization secrets, therefore we need to pass them as inputs to the tool. This commit updates the avocado-project action to use MR. Avocados IDs as inputs.