### PR TITLE
Remove static-checks from avocado-ci-tools

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,11 +31,11 @@ runs:
       uses: actions/checkout@v2
       with:
         repository: avocado-framework/avocado-static-checks
-        path: avocado-ci-tools/static-checks
+        path: static-checks
     - if: ${{ inputs.avocado-static-checks  == 'true' }}
       run: |
-        pip3 install -r avocado-ci-tools/static-checks/requirements.txt
-        avocado-ci-tools/static-checks/run-static-checks
+        pip3 install -r static-checks/requirements.txt
+        static-checks/run-static-checks
       shell: bash
     # --- avocado-project ---
     - if: ${{ inputs.avocado-project == 'true' }}


### PR DESCRIPTION
Because static-checks lint script searches for config file in specific directory `$(dirname "$0")/../avocado-static-checks.conf` we need to make sure that the static-checks repo is fetched into `repo_root_dir/static-checks/` dir. This change will ensure that the pylint will use the right configuration from a project.

This PR will help to fix the CI issue in https://github.com/avocado-framework/aautils/pull/37